### PR TITLE
Fix Confirmdialog defaultFocus type

### DIFF
--- a/src/app/components/confirmdialog/confirmdialog.ts
+++ b/src/app/components/confirmdialog/confirmdialog.ts
@@ -283,7 +283,7 @@ export class ConfirmDialog implements AfterContentInit, OnInit, OnDestroy {
      * Element to receive the focus when the dialog gets visible.
      * @group Props
      */
-    @Input() defaultFocus: 'accept' | 'reject' | 'close' = 'accept';
+    @Input() defaultFocus: 'accept' | 'reject' | 'close' | 'none' = 'accept';
     /**
      * Object literal to define widths per screen size.
      * @group Props


### PR DESCRIPTION
In  Confirmdialog component , defaultFocus 'none' type is missing.